### PR TITLE
Improve README with API authentication details

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,26 @@ Install the required Python packages with:
 pip install -r requirements.txt
 ```
 
+## API Authentication
+
+Authenticated requests require a `.env` file in the project root that sets
+`CODEFORCES_API_KEY` and `CODEFORCES_API_SECRET`:
+
+```bash
+CODEFORCES_API_KEY=<your key>
+CODEFORCES_API_SECRET=<your secret>
+```
+
+`fetch_codeforces_problems.py` loads these variables with `load_dotenv`
+(see lines 9-13):
+
+```python
+from dotenv import load_dotenv
+load_dotenv()
+api_key = os.getenv("CODEFORCES_API_KEY")
+api_secret = os.getenv("CODEFORCES_API_SECRET")
+```
+
 ## Directory Structure
 
 ```


### PR DESCRIPTION
## Summary
- describe how to configure Codeforces API credentials via `.env`
- show code snippet from `fetch_codeforces_problems.py` that loads the variables

## Testing
- `python -m py_compile fetch_codeforces_problems.py`
- `python -m py_compile prepare_data.py data_processing.py run_all_analysis.py vis_heatmap.py vis_force_directed.py vis_umap.py tag_ppmi_visualization.py`


------
https://chatgpt.com/codex/tasks/task_e_6843ed86b6fc83298042a2a87e183a32